### PR TITLE
Crashlytics 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,8 +45,8 @@ dependencies {
     implementation 'com.airbnb.android:lottie:3.1.0'
     implementation 'com.github.bumptech.glide:glide:4.10.0'
     implementation "io.reactivex.rxjava2:rxandroid:2.1.1"
-    implementation('com.crashlytics.sdk.android:crashlytics:2.10.1@aar') {
-        transitive = true
-    }
+    implementation 'com.google.firebase:firebase-analytics:17.2.1'
+    implementation 'com.crashlytics.sdk.android:crashlytics:2.10.1'
     implementation 'androidx.core:core-ktx:1.1.0'
 }
+apply plugin: 'com.google.gms.google-services'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,22 @@ android {
     testOptions {
         unitTests.returnDefaultValues = true
     }
-
+    signingConfigs {
+        sign {
+            keyAlias 'openweather'
+            keyPassword 'tuna1234'
+            storeFile file('../release/release.jks')
+            storePassword 'tuna1234'
+        }
+    }
+    buildTypes {
+        release {
+            signingConfig signingConfigs.sign
+        }
+        debug {
+            signingConfig signingConfigs.sign
+        }
+    }
 }
 
 dependencies {

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,0 +1,40 @@
+{
+  "project_info": {
+    "project_number": "516160825280",
+    "firebase_url": "https://openweather-35baf.firebaseio.com",
+    "project_id": "openweather-35baf",
+    "storage_bucket": "openweather-35baf.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:516160825280:android:dd29321e3cd85ab4ccca25",
+        "android_client_info": {
+          "package_name": "com.karrel.openweather"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "516160825280-bn6fvv8aa6vuj5mjifvnej6s8r03ci3r.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyBTl-FMjBaX7Nw7Eok0jkWuu7DxjW_X5SY"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "516160825280-bn6fvv8aa6vuj5mjifvnej6s8r03ci3r.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/main/java/com/karrel/openweather/base/BaseActivity.kt
+++ b/app/src/main/java/com/karrel/openweather/base/BaseActivity.kt
@@ -23,6 +23,7 @@ open class BaseActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        Crashlytics.log(android.util.Log.DEBUG, "onCreate", javaClass.simpleName)
         lifecycle.addObserver(disposables)
         Fabric.with(this, Crashlytics())
         observeProgress()

--- a/app/src/main/java/com/karrel/openweather/base/BaseApplication.kt
+++ b/app/src/main/java/com/karrel/openweather/base/BaseApplication.kt
@@ -16,7 +16,7 @@ class BaseApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
-//        Fabric.with(this, Crashlytics())
+        Fabric.with(this, Crashlytics())
         Crashlytics.log("시작됨")
 
         instance = this

--- a/app/src/main/java/com/karrel/openweather/base/BaseApplication.kt
+++ b/app/src/main/java/com/karrel/openweather/base/BaseApplication.kt
@@ -2,6 +2,9 @@ package com.karrel.openweather.base
 
 import android.app.Application
 import android.content.Context
+import com.crashlytics.android.Crashlytics
+import com.google.firebase.analytics.FirebaseAnalytics
+import io.fabric.sdk.android.Fabric
 import team.tuna.openweather.constant.appContext
 
 class BaseApplication : Application() {
@@ -13,6 +16,8 @@ class BaseApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+//        Fabric.with(this, Crashlytics())
+        Crashlytics.log("시작됨")
 
         instance = this
         appContext = applicationContext

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.google.gms:google-services:4.3.3'
         classpath 'io.fabric.tools:gradle:1.31.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## 무엇을
-Crashlytics 를

## 왜
-Crashlytics 오류 보고를 위한여

## 어떻게
-Firebase에 test 용과 운영용을 분리 하여 만들었음.

## 참고
문서
[crashlytics 문서](https://firebase.google.com/docs/crashlytics/get-started?platform=android)
[이슈내용](https://console.firebase.google.com/project/openweather-35baf/crashlytics/app/android:com.karrel.openweather/issues)
[튜나계정>권한추가 후 이용가능](https://console.firebase.google.com/project/openweather-35baf/settings/iam)

첨부소스 중 주석처리된부분

```
class MyApplication : Application() {
    override fun onCreate() {
        super.onCreate()
        Fabric.with(this, Crashlytics())

```
